### PR TITLE
Fix note numbering duplication

### DIFF
--- a/molyproto-main/molyproto/client/src/components/chat/ModelSelectModal.tsx
+++ b/molyproto-main/molyproto/client/src/components/chat/ModelSelectModal.tsx
@@ -33,6 +33,11 @@ const AVAILABLE_MODELS: Model[] = [
     name: "GPT-4 Turbo",
     description: "Latest GPT-4 model with improved performance",
   },
+  {
+    id: "o3",
+    name: "O3",
+    description: "Powerful O3 model",
+  },
 ];
 
 const ModelSelectModal: React.FC<ModelSelectModalProps> = ({

--- a/molyproto-main/molyproto/client/src/components/chat/SummaryPanel.tsx
+++ b/molyproto-main/molyproto/client/src/components/chat/SummaryPanel.tsx
@@ -51,7 +51,15 @@ const SummaryPanel: React.FC = () => {
       // Merge multiple notes of the same type
       const mergedContent = groupNotes.map((note, index) => {
         // Remove the tag and timestamp from the note content
-        let content = note.replace(/^【.+?】\n\*(.+?)\*/, '').replace(/^【.+?】/, '').trim();
+        let content = note
+          .replace(/^【.+?】\n\*(.+?)\*/, '')
+          .replace(/^【.+?】/, '')
+          .trim();
+
+        // Strip existing numbering like "## 一、" or "1." to avoid nested numbers
+        content = content
+          .replace(/^#{1,6}\s*[一二三四五六七八九十]+、?\s*\n?/, '')
+          .replace(/^\d+[\.、]\s*/, '');
         
         // Handle Markdown headers
         content = content.replace(/^(#{1,6})\s(.+)$/gm, (match, hashes, title) => {
@@ -122,8 +130,14 @@ const SummaryPanel: React.FC = () => {
   const handleNoteSave = () => {
     if (editingNote && summary) {
       const notes = summary.split('\n\n---\n\n');
-      const updatedNotes = notes.map(note => 
-        note === editingNote ? editValue : note
+
+      // Remove numbering prefixes before saving the edited note
+      const processedValue = editValue
+        .replace(/^#{1,6}\s*[一二三四五六七八九十]+、?\s*\n?/, '')
+        .replace(/^\d+[\.、]\s*/, '');
+
+      const updatedNotes = notes.map(note =>
+        note === editingNote ? processedValue : note
       );
       const newSummary = updatedNotes.join('\n\n---\n\n');
       


### PR DESCRIPTION
## Summary
- clean numbering prefix before rendering merged notes
- strip numbering when saving edited notes
- add `o3` model option to model selection

## Testing
- `npm run check` *(fails: Cannot find type definition file)*